### PR TITLE
Fix 404 to about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gravitational Careers
 
-These are currently the open positions at Gravitational. However, we are always looking for exceptional people. If you are passionate about <a href="http://gravitational.com/about.html">what we are doing</a>, feel free to email us with your resume or links to your work: <a href="mailto:jobs@gravitational.com">jobs@gravitational.com</a>.
+These are currently the open positions at Gravitational. However, we are always looking for exceptional people. If you are passionate about <a href="http://gravitational.com/about/">what we are doing</a>, feel free to email us with your resume or links to your work: <a href="mailto:jobs@gravitational.com">jobs@gravitational.com</a>.
 
 * [Golang/Linux systems engineer](senior-backend-engineer.md)
 * [UX/Product Leader](product-design-leader.md)


### PR DESCRIPTION
Also note that on your about page, the link to this page is a 404. On the gravitational.com/about page, it points to https://github.com/gravitational/careers/blob/master/careers.md, but it should be pointing to https://github.com/gravitational/careers/blob/master/README.md.