### PR TITLE
Clarify that questions should target the highest level

### DIFF
--- a/challenges/platform/automation.md
+++ b/challenges/platform/automation.md
@@ -46,7 +46,7 @@ E10FA20A:01BB translates to 10.162.15.225:443
 ## Level 1:
 
 ### Description
-Write a program that reads `/proc/net/tcp` every 10 seconds, and reports any new connections. 
+Write a program that reads `/proc/net/tcp` every 10 seconds, and reports any new connections.
 
 Sample Output:
 ```
@@ -59,10 +59,12 @@ Sample Output:
 Include a readme with the program that explains any dependencies and how to build and execute the program. The interview panel will build and test the program.
 
 ### Questions
+Please answer all questions in response to your final solution. For example: if you complete the challenge at Level 3, the answer to "How would you prove the code is correct?" should include proving that portscans are actually blocked.
+
 1. How would you prove the code is correct?
 2. How would you make this solution better?
 3. Is it possible for this program to miss a connection?
-4. If you weren't following these requirements, how would you solve the problem of logging every new connection? 
+4. If you weren't following these requirements, how would you solve the problem of logging every new connection?
 
 ## Level 2:
 Implement all of the level 1 requirements plus:


### PR DESCRIPTION
We've had several candidates answer questions in response to the level
the questions are at (e.g. at L1 saying "I'd use libpcap" when they implemented a
libpcap based solution at l4).