### PR TITLE
frontend: Replace mention of Airbnb coding style

### DIFF
--- a/challenges/frontend/challenge.md
+++ b/challenges/frontend/challenge.md
@@ -162,7 +162,7 @@ This is a test challenge and we have no intent of using the code you’ve submit
 
 These are the areas we will be evaluating in the submission:
 
-* Use consistent coding style. We follow [AirBnB Coding Style](https://github.com/airbnb/javascript) for JS and use [prettier](https://prettier.io/) code formatter.
+* Use consistent coding style. We follow recommended [ESLint](https://eslint.org/docs/user-guide/configuring/configuration-files#using-eslintrecommended) and [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react#configuration) rules for JS and use [prettier](https://prettier.io/) code formatter.
 * Create a few unit-tests for scenarios you think make sense.
 * Make sure builds are reproducible. Pick any vendoring/packaging system that will allow us to get consistent build results.
 * Ensure error handling and error reporting is consistent. The app should report clear errors and not crash under non-critical conditions.


### PR DESCRIPTION
Grepping through the project and git history, it doesn't look like we ever used eslint-config-airbnb. Having spent a month in the project, it seems that our linter rules are not as strict as Airbnb's JS style guide, so let's replace mentions of Airbnb coding style with stuff that we actually use.

To give some perspective as someone who was a candidate just a while ago, when I saw the mention of Airbnb's coding style I was like 😩😫. I find Airbnb's ESLint config to be counterproductive, but I included it in my design doc anyway (because it seemed to be used by the team), only to silently drop it after rediscovering how unnecessarily pedantic it is.