### PR TITLE
Further updates to SRE challenge

### DIFF
--- a/challenges/sre/challenge.md
+++ b/challenges/sre/challenge.md
@@ -160,7 +160,7 @@ but, at a minimum, please include the following:
 * HTTP health check verifying Kubernetes connectivity
 * HTTP API must cache the replica count by watching for changes to Deployments.
   Read-only requests should not each trigger a request to the cluster.
-  It is acceptable to use either go-client or controller-runtime to implement this.
+  It is acceptable to use either client-go or controller-runtime to implement this.
 * Secure connections between the HTTP API and caller with mTLS
 * One or two tests that cover happy and unhappy scenarios
 
@@ -186,7 +186,7 @@ but, at a minimum, please include the following:
 * gRPC or HTTP health check verifying Kubernetes connectivity
 * gRPC API must cache the replica count by watching for changes to Deployments.
   Read-only requests should not each trigger a request to the cluster.
-  It is acceptable to use either go-client or controller-runtime to implement this.
+  It is acceptable to use either client-go or controller-runtime to implement this.
 * Secure connections between the gRPC API and caller with mTLS
 * Server must store the desired state in a CRD (per-deployment) and reconcile the deployment to that state.
   (gRPC API endpoints only need to read the real, current value.) 

--- a/challenges/sre/challenge.md
+++ b/challenges/sre/challenge.md
@@ -160,6 +160,7 @@ but, at a minimum, please include the following:
 * HTTP health check verifying Kubernetes connectivity
 * HTTP API must cache the replica count by watching for changes to Deployments.
   Read-only requests should not each trigger a request to the cluster.
+  It is acceptable to use either go-client or controller-runtime to implement this.
 * Secure connections between the HTTP API and caller with mTLS
 * One or two tests that cover happy and unhappy scenarios
 
@@ -173,8 +174,7 @@ but, at a minimum, please include the following:
 ### Deployment
 
 * Create a helm chart for the service that includes at least: a Deployment, ServiceAccount and Service
-* Deploy releases of the API Server to a Kubernetes cluster (and possible dependencies)
-* Upgrade releases of the API Server to a Kubernetes cluster (and possible dependencies)
+* Deploy releases of the API Server to a Kubernetes cluster along with any dependencies
 
 ## Level 5
 
@@ -186,7 +186,8 @@ but, at a minimum, please include the following:
 * gRPC or HTTP health check verifying Kubernetes connectivity
 * gRPC API must cache the replica count by watching for changes to Deployments.
   Read-only requests should not each trigger a request to the cluster.
-* Secure connections between the HTTP API and caller with mTLS
+  It is acceptable to use either go-client or controller-runtime to implement this.
+* Secure connections between the gRPC API and caller with mTLS
 * Server must store the desired state in a CRD (per-deployment) and reconcile the deployment to that state.
   (gRPC API endpoints only need to read the real, current value.) 
 * One or two tests that cover happy and unhappy scenarios
@@ -197,15 +198,12 @@ but, at a minimum, please include the following:
 * Ability to run the server (inside and outside Kubernetes)
 * Ability to execute integration tests against the local Kubernetes cluster
 * Produce production ready releases (binaries and docker image)
-* Deploy and manage a local Kubernetes Cluster
-* Deploy and upgrade to the local Kubernetes Cluster with no service interruption
 
 ### Deployment
 
 * Create a helm chart for the service
-* Deploy releases of the API Server to a Kubernetes cluster (and possible dependencies)
-* Upgrade releases of the API Server to a Kubernetes cluster (and possible dependencies)
-* Include a production Deployment of this service, including but not limited to: Deployment, Role, RoleBinding, ServiceAccount, Service
+* Include production-level packaging for this service, including but not limited to: Deployment, Role, RoleBinding, ServiceAccount, Service
+* Deploy releases of the API Server to a Kubernetes cluster along with any dependencies
 
 # Guidance
 


### PR DESCRIPTION
This PR makes a few additional tweaks / simplifications to the SRE challenge:
- Fix incorrect reference to API type for L5 challenge
- Directly suggest controller-runtime to help with caching
- Remove explicit requirement to demonstrate upgrading the helm chart
- Remove requirement to creation automation around local Kubernetes cluster management