### PR TITLE
Remove reference to multiple languages in systems challenge

### DIFF
--- a/challenges/systems/challenge-1.md
+++ b/challenges/systems/challenge-1.md
@@ -230,9 +230,7 @@ Teleport focuses on networking, infrastructure and security.
 These are the areas we will be evaluating in the submission:
 
 * Use consistent coding style. We follow
-  [Go Coding Style](https://github.com/golang/go/wiki/CodeReviewComments) for
-  the Go language. If you are going to use a different language, please pick
-  coding style guidelines and let us know what they are.
+  [Go Coding Style](https://github.com/golang/go/wiki/CodeReviewComments).
 * Tests exist for happy path and error scenarios for key components of the challenge.
 * Make sure builds are reproducible.
 * Ensure error handling and error reporting is consistent. The system should


### PR DESCRIPTION
Hi, apologies if this is not for outsiders to contribute to, but I saw an opportunity to improve this, so I thought I'd submit it.

- Since commit b8e918da01f876a2eadbd4f42f8f528796f0b2b2, Go is the only language allowed
- The way this is currently written is a little confusing, as it conflicts with the advice below in the 'tools' section which states only Go should be used