### PR TITLE
Clarify and unify design document expectations

### DIFF
--- a/challenges/fullstack/challenge.md
+++ b/challenges/fullstack/challenge.md
@@ -254,8 +254,9 @@ A few notes about the design document:
 
 * We expect the design document to be complete roughly within the first week.
   This is to ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. Two to three pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents, it is difficult to evaluate what
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be

--- a/challenges/mobile/challenge.md
+++ b/challenges/mobile/challenge.md
@@ -169,8 +169,9 @@ A few notes about the design document:
   non-expert audience — someone who's as strong a teacher as they are a developer.
 * We expect the design document to be complete roughly within the first week.
   This is to ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. Two to three pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents, it is difficult to evaluate what
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be

--- a/challenges/product/challenge-1.md
+++ b/challenges/product/challenge-1.md
@@ -58,10 +58,10 @@ would like to learn about Teleport.
 Before writing the actual code, create a brief design document in markdown and
 share with the team via a GitHub pull request.
 
-This document should consist of key trade-offs and key design approaches. Please
-avoid writing an overly detailed design document. Use this document to make sure
-demonstrate that you've investigated the problem space. The team will review your
-design and provide feedback by commenting on the pull request.
+There is no required format or word count for the design document. The design
+should convey your plan to satisfy the requirements, possible alternatives, and
+the tradeoffs informing your approach. The team will review your design and
+provide feedback by commenting on the pull request.
 
 After the team has approved your design document, you may begin submitting pull
 requests with the implementation.

--- a/challenges/security-automation/challenge.md
+++ b/challenges/security-automation/challenge.md
@@ -53,8 +53,9 @@ A few notes about the design document:
 
 * Try to get the design document approved within the first 2-3 days. This is to
   ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. One to two pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents. It is difficult to evaluate which
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be reviewed.

--- a/challenges/sre/challenge.md
+++ b/challenges/sre/challenge.md
@@ -55,8 +55,9 @@ A few notes about the design document:
 
 * Try to get the design document approved within the first 2-3 days. This is to
   ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. Two to three pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents. It is difficult to evaluate which
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be reviewed.

--- a/challenges/systems-intern/challenge.md
+++ b/challenges/systems-intern/challenge.md
@@ -46,8 +46,9 @@ A few notes about the design document:
 
 * Try to get the design document approved within the first 2-3 days. This is to
   ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. Two to three pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents. It is difficult to evaluate which
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be reviewed.

--- a/challenges/systems/challenge-1-windows.md
+++ b/challenges/systems/challenge-1-windows.md
@@ -53,8 +53,9 @@ A few notes about the design document:
 
 * Try to get the design document approved within the first 2-3 days. This is to
   ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. Two to three pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents. It is difficult to evaluate which
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be reviewed.

--- a/challenges/systems/challenge-1.md
+++ b/challenges/systems/challenge-1.md
@@ -52,8 +52,9 @@ A few notes about the design document:
 
 * Try to get the design document approved within the first 2-3 days. This is to
   ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. Two to three pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents. It is difficult to evaluate which
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be reviewed.

--- a/challenges/systems/challenge-2.md
+++ b/challenges/systems/challenge-2.md
@@ -50,8 +50,9 @@ A few notes about the design document:
 
 * Try to get the design document approved within the first 2-3 days. This is to
   ensure you have enough time to work on the implementation.
-* Avoid writing an overly detailed design document. Two to three pages is
-  sufficient.
+* There is no required format or word count for the design document. The design
+  should convey your plan to satisfy the requirements, possible alternatives,
+  and the tradeoffs informing your approach.
 * Avoid sending us draft design documents. It is difficult to evaluate which
   parts are draft and which parts are complete. Instead we encourage asking
   questions in Slack and sharing a design document that is ready to be reviewed.


### PR DESCRIPTION
This is an attempt to reduce confusion around design document verbosity and page count by explicitly stating what we want to see in a design document.